### PR TITLE
really early version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'cpp' ]
+        language: [ 'go' ]
 
     steps:
     - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -12,8 +12,39 @@ NOTE: This is still a really early prototype so not much of a build system into 
 go build orunmila
 ```
 
-## Examples
 
+## Examples
+* Import words from `lista.txt` and tag as `lista`
+  ```
+  orunmila -tags lista lista.txt
+  ```
+
+* List words with tag as `lista`
+  ```
+  orunmila -tags lista
+  ```
+
+* Import words from `listb.txt` and tag as `listb`
+  ```
+  orunmila -tags listb listb.txt
+  ```
+
+* List words with tag as `listb`
+  ```
+  orunmila -tags listb
+  ```
+
+* Import words from `lista.txt` and `listb.txt` and tag as `listc`
+  ```
+  orunmila -tags listc lista.txt listb.txt
+  ```
+
+* List words with tag as `listc` (should return all words)
+  ```
+  orunmila -tags listc
+  ```
+
+### Drupal example
 Take the following hypothetical scenario, we have a target system that is based on drupal. We have already populated our `orunmila.db` with appropriate words and tags before hand.
 
 Using orunmila we extract the keywords that match our criteria
@@ -21,7 +52,6 @@ Using orunmila we extract the keywords that match our criteria
 orunmila -tags drupal,dir,nginx,php >drupal_words.txt
 ffuf -w drupal_words.txt -u https://drupal-target/FUZZ
 ```
-
 
 The tool supports using specific database files ie
 ```

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
 # Orunmila
 a simple system to refine and produce lists for your bugbounty and pen-test engagements.
 
-The idea behind it is fairly simple a small sqlite(??) database with each word reflecting categories that it can be applied to (ie API, nginx, PHP etc)
-This way we can have a huge collection and ask it to give only the given "words" that seem to match your current engagement.
+The idea behind it is fairly simple a small sqlite(??) database with each word associated tags. Each word in the dictionary can be associated with multiple tags.
+This provides for a way to later request the words from a database based on specific tags and use the generated wordlist with you normal tools, be it ffuf, dirbuster etc.
 
-Some imaginary use cases
+
+## Building
+NOTE: This is still a really early prototype so not much of a build system into the mix.
+
 ```sh
-orunmila -tags nginx,soap,swift,api,xml >wordlist.txt
+go build orunmila
 ```
 
-The tool could optionally support extra word databases ie gathered from specific programs.
+## Examples
+
+Take the following hypothetical scenario, we have a target system that is based on drupal. We have already populated our `orunmila.db` with appropriate words and tags before hand.
+
+Using orunmila we extract the keywords that match our criteria
+```sh
+orunmila -tags drupal,dir,nginx,php >drupal_words.txt
+ffuf -w drupal_words.txt -u https://drupal-target/FUZZ
+```
+
+
+The tool supports using specific database files ie
 ```
 orunmila -db programXYZ.db -tags nginx,soap,swift,api,xml
 ```
 
-The is also a need to be able to import and tag lists easy initially.
+You can use Orunmila to import wordlists into your database with given set of tags. Existing words will have their tags updated to reflect the new ones
 ```
-orunmila -db programXYZ.db -tags generic -i file_to_extract_words
-```
-
-Continued imports of the same file can be utilized to add tags for the words on our database matching the given file (assuming we have it imported already from the previous run under the `generic` tag)
-```
-orunmila -db programXYZ.db -tags applicationABC -i file_to_extract_words
+orunmila -db programXYZ.db -tags raft,directories,manual raft-medium-directories.txt
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+* [ ] use log.* functions instead of fmt.println where appropriate
+* [ ] only open the database for write when we do imports. in any other case `?mode=readonly`
+* [ ] add tags and words deletion capabilities
+* [ ] add exclude tags filtering (ie `-tags a,b,c -etags d` will list words from a,b,c tags and that dont have d tag)

--- a/lista.txt
+++ b/lista.txt
@@ -1,0 +1,4 @@
+unique1
+unique2
+unique3
+common1

--- a/listb.txt
+++ b/listb.txt
@@ -1,0 +1,4 @@
+unique9
+unique4
+unique5
+common1

--- a/orunmila.go
+++ b/orunmila.go
@@ -196,13 +196,17 @@ func main() {
 	dbPtr := flag.String("db", "orunmila.db", "the database filename (default: orunmila.db)")
 	tagsPtr := flag.String("tags", "", "a comma separated list of the tags to use")
 	wordsPtr := flag.String("words", "", "a comma separated list of words to look for")
+	debugPtr := flag.Bool("debug", false, "enable debug")
 
 	flag.Parse()
+	if *debugPtr {
+		log.SetLevel(log.DebugLevel)
+	}
 
-	log.Println("using db:", *dbPtr)
-	log.Println("using tags:", *tagsPtr)
-	log.Println("using words:", *wordsPtr)
-
+	log.Debugln("using db:", *dbPtr)
+	log.Debugln("using tags:", *tagsPtr)
+	log.Debugln("using words:", *wordsPtr)
+	log.Debugln("debug:", *debugPtr)
 	// check if db file exists
 	file, err := os.Open(*dbPtr)
 	file.Close()

--- a/orunmila.go
+++ b/orunmila.go
@@ -177,7 +177,7 @@ func searchWords(db sql.DB, tags string) {
 	tagsToArray(tags)
 	importTags(db)
 	log.Println(Tags)
-	rows, err := db.Query(fmt.Sprintf("select t1.name from words as t1 left join wt as t2 on t2.word_id=t1.id WHERE t2.tag_id IN (%s)", TagsToString()))
+	rows, err := db.Query(fmt.Sprintf("select t1.name from words as t1 left join wt as t2 on t2.word_id=t1.id WHERE t2.tag_id IN (%s) group by t1.id", TagsToString()))
 	check(err)
 	defer rows.Close()
 	for rows.Next() {

--- a/orunmila.go
+++ b/orunmila.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func createDB(dbname string) {
+	db, err := sql.Open("sqlite3", dbname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	sqlStmt := `
+	create table words (id integer not null primary key AUTOINCREMENT, name text NOT NULL UNIQUE);
+	create table tags (id integer not null primary key AUTOINCREMENT, name text NOT NULL UNIQUE);
+	create table wt (word_id integer not null , tag_id integer not null, FOREIGN KEY(word_id) REFERENCES words(id),FOREIGN KEY(tag_id) REFERENCES tags(id),PRIMARY KEY(word_id,tag_id));
+	`
+	_, err = db.Exec(sqlStmt)
+	if err != nil {
+		log.Printf("%q: %s\n", err, sqlStmt)
+		return
+	}
+}
+func importTags(db sql.DB, tags string) {
+	// explode tags by comma
+	// perform insert of the tags i they dont exist
+}
+func importWords(db sql.DB, tags string, filename string) {
+
+	// TODO: Open file
+	tx, err := db.Begin()
+	if err != nil {
+		log.Fatal(err)
+	}
+	stmt, err := tx.Prepare("insert into words(name) values(?)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer stmt.Close()
+	for i := 0; i < 100; i++ {
+		_, err = stmt.Exec(fmt.Sprintf("%03d", i))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	err = tx.Commit()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func searchWords(db sql.DB, tags string) {
+	rows, err := db.Query("select id, name from words")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int
+		var name string
+		err = rows.Scan(&id, &name)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(id, name)
+	}
+	err = rows.Err()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func main() {
+	dbPtr := flag.String("db", "foo.db", "the database filename")
+	tagsPtr := flag.String("tags", "", "a comma separated list of the tags to use")
+
+	flag.Parse()
+
+	fmt.Println("using db:", *dbPtr)
+	fmt.Println("using tags:", *tagsPtr)
+
+	// FIXME: check fo db existence first
+	file, err := os.Open(*dbPtr)
+	file.Close()
+	if errors.Is(err, os.ErrNotExist) {
+		fmt.Println("database does not exist, creating...")
+		createDB(*dbPtr)
+	}
+	db, err := sql.Open("sqlite3", *dbPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if flag.NArg() == 0 {
+		fmt.Println("no filename given, performing a search")
+		searchWords(*db, *tagsPtr)
+	} else {
+		fmt.Println("performing an import on the given files:", flag.Args())
+		fmt.Println("arg0:", flag.Arg(0))
+		for i := 0; i < flag.NArg(); i++ {
+			importWords(*db, *tagsPtr, flag.Arg(i))
+		}
+	}
+
+	os.Exit(0)
+}

--- a/orunmila.go
+++ b/orunmila.go
@@ -105,8 +105,8 @@ func main() {
 		searchWords(*db, *tagsPtr)
 	} else {
 		fmt.Println("performing an import on the given files:", flag.Args())
-		fmt.Println("arg0:", flag.Arg(0))
 		for i := 0; i < flag.NArg(); i++ {
+			fmt.Println("importing:", flag.Arg(i))
 			importWords(*db, *tagsPtr, flag.Arg(i))
 		}
 	}

--- a/orunmila.go
+++ b/orunmila.go
@@ -87,7 +87,7 @@ func main() {
 	fmt.Println("using db:", *dbPtr)
 	fmt.Println("using tags:", *tagsPtr)
 
-	// FIXME: check fo db existence first
+	// FIXME: check for db existence first
 	file, err := os.Open(*dbPtr)
 	file.Close()
 	if errors.Is(err, os.ErrNotExist) {

--- a/orunmila.go
+++ b/orunmila.go
@@ -173,7 +173,7 @@ func importWords(db sql.DB, tags string, filename string) {
 //
 // Search for words matching tags
 //
-func searchWords(db sql.DB, tags string) {
+func searchWordsByTagIds(db sql.DB, tags string) {
 	tagsToArray(tags)
 	importTags(db)
 	log.Println(Tags)
@@ -220,7 +220,7 @@ func main() {
 
 	if flag.NArg() == 0 {
 		log.Println("no filename given, performing a search")
-		searchWords(*db, *tagsPtr)
+		searchWordsByTagIds(*db, *tagsPtr)
 	} else {
 		log.Println("performing an import on the given files:", flag.Args())
 		for i := 0; i < flag.NArg(); i++ {


### PR DESCRIPTION
This is a really early skeleton for the tool.

* Added support for the following options
```
Usage of ./orunmila:
  -db string
        the database filename (default: orunmila.db) (default "orunmila.db")
  -debug
        enable debug
  -tags string
        a comma separated list of the tags to use
  -words string
        a comma separated list of words to look for (not implemented yet)
```

* Checks if the database file exists. If not create it on the spot with our schema.
* When a filename is given last import operation is initiated
* multiple filenames can be given `./orunmila -tags a,b,c wordlist1.txt wordlist2.txt`
* Added some initial checks for specific arguments
* Provide 3 local functions `createDB(dbname string)`, `importTags(db sql.DB, tags string)`, `importWords(db sql.DB, tags string, filename string)` and `searchWords(db sql.DB, tags string)`

**examples**
![](https://cdn.discordapp.com/attachments/1012759357982773268/1049034181075800084/image.png)

![](https://cdn.discordapp.com/attachments/1012759357982773268/1049034648098971688/image.png)
