### PR TITLE
Remove tags that dont exist when searching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SOURCE=orunmila.go
 
 .PHONY: all
 
-all: dep test test_coverage vet lint build
+all: dep test test_coverage vet build
 
 
 build:
@@ -24,8 +24,8 @@ dep:
 vet:
 	go vet
 
-lint:
-	golangci-lint run --enable-all
+#lint:
+#	golangci-lint run --enable-all
 
 run:
 	./${BINARY_NAME}


### PR DESCRIPTION
This PR does the following
* Fix a logic bug that caused the program to always exit with ERR:nil from #4 
* Add a removeEmptyTags to remove tags we didnt find in our database before we prepare the search query
* Temporarily remove `lint` target to ensure `make` runs without errors