### PR TITLE
Introduce `vacuum` and `add` subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ go build orunmila.go
 ```
 
 
+## Subcommands
+* add words from the cli
+  ```sh
+  orunmila add -tags a,b,c word1 word2 word3
+  ```
+* import words from a file
+  ```sh
+  orunmila import -tags a,b,c filename
+  ```
+* search words
+```
+  orunmila search -tags a,b,c filename
+```
+* vacuum database
+  ```sh
+  orunmila vacuume a
+  ```
+
 ## Examples
 * Import words from `lista.txt` and tag as `lista`
   ```
@@ -30,27 +48,27 @@ go build orunmila.go
 
 * List words with tag as `lista`
   ```
-  orunmila -tags lista
+  orunmila search -tags lista
   ```
 
 * Import words from `listb.txt` and tag as `listb`
   ```
-  orunmila -tags listb listb.txt
+  orunmila import -tags listb listb.txt
   ```
 
 * List words with tag as `listb`
   ```
-  orunmila -tags listb
+  orunmila search -tags listb
   ```
 
 * Import words from `lista.txt` and `listb.txt` and tag as `listc`
   ```
-  orunmila -tags listc lista.txt listb.txt
+  orunmila import -tags listc lista.txt listb.txt
   ```
 
 * List words with tag as `listc` (should return all words)
   ```
-  orunmila -tags listc
+  orunmila search -tags listc
   ```
 
 ### Drupal example

--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,9 @@
 * [x] Make sure the database files are created into the current working directory and not wherever the binary is installed
 * [ ] Add help subcommand with usage
 * [ ] Make operations into subcommands
-  * [ ] import: imports a file into the database
-  * [ ] search: searches the database for the given tags
-  * [ ] add: add entries to the database from the cli
+  * [x] import: imports a file into the database
+  * [x] search: searches the database for the given tags
+  * [x] add: add entries to the database from the cli
   * [ ] delw: delete words from the database `-words` and/or `-tags`
   * [ ] delt: delete tags from the database `-words` and/or `-tags`
   * [ ] delwt: delete associations between `-words` and/or `-tags`

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,20 @@
 # TODO
-* [ ] use log.* functions instead of fmt.println where appropriate
+* [x] use `log.*` functions instead of `fmt.println` where appropriate.
 * [x] only open the database for write when we do imports. in any other case `?mode=readonly`
-* [ ] add tags and words deletion capabilities
 * [ ] add exclude tags filtering (ie `-tags a,b,c -etags d` will list words from a,b,c tags and that dont have d tag)
-* [ ] Make a proper module structure and ensure the dependencies get installed from `go.mod`
+* [x] Make a proper module structure and ensure the dependencies get installed from `go.mod`
 * [ ] Check if we can add loading database to memory to speed things up
 * [ ] Split operations into multiple files to ease development and avoid conflicts in merge
 * [ ] Add Github workflow to build binary releases
 * [ ] Add support for case sensitive words if needed (this involves using `collate nocase` on the schema and our search)
 * [ ] Add support to search for `-words` as well as `-tags`
 * [x] Make sure the database files are created into the current working directory and not wherever the binary is installed
-* [ ] Add help subcommand with usage
 * [ ] Make operations into subcommands
+  * [ ] help: Details usage of all operations
   * [x] import: imports a file into the database
   * [x] search: searches the database for the given tags
   * [x] add: add entries to the database from the cli
   * [ ] delw: delete words from the database `-words` and/or `-tags`
   * [ ] delt: delete tags from the database `-words` and/or `-tags`
   * [ ] delwt: delete associations between `-words` and/or `-tags`
-  * [ ] vacuum: pack the database to save space
+  * [x] vacuum: pack the database to save space

--- a/orunmila.go
+++ b/orunmila.go
@@ -48,7 +48,7 @@ func getTagId(db *sql.DB, tag string) int64 {
 func getWordId(db *sql.DB, word string) int64 {
 	var id int64
 
-	err := db.QueryRow("select id from tags where name = ?", word).Scan(&id)
+	err := db.QueryRow("select id from words where name = ?", word).Scan(&id)
 	if err != nil {
 		id = -1
 	}
@@ -243,6 +243,73 @@ func isFileExists(filename string) bool {
 }
 
 // parse args of the import subcommand and exec it
+func addSubcmd(args []string) {
+	path, err := os.Getwd()
+	check(err)
+
+	flag := flag.NewFlagSet("add", flag.ExitOnError)
+	var (
+		dbPtr   = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		tagsPtr = flag.String("tags", "", "a comma separated list of the tags to use")
+	)
+
+	flag.Parse(args)
+
+	log.Infoln("Importing the given words:", flag.Args())
+
+	dsn := fmt.Sprintf("file:%s?mode=rw", *dbPtr)
+	db, err := sql.Open("sqlite3", dsn)
+	check(err)
+	defer db.Close()
+
+	Tags = stringToArray(*tagsPtr)
+	importTags(db)
+
+	tx, err := db.Begin()
+	check(err)
+
+	wordsStmt, err := tx.Prepare("insert or ignore into words(name) values(?)")
+	check(err)
+	defer wordsStmt.Close()
+
+	wtStmt, err := tx.Prepare("insert or ignore into wt(word_id,tag_id) values(?,?)")
+	check(err)
+	defer wtStmt.Close()
+
+	for i := 0; i < flag.NArg(); i++ {
+		log.Println("adding word:", flag.Arg(i))
+		word := strings.TrimSpace(flag.Arg(i))
+		var word_id int64
+		if word != "" {
+			log.Debugln("importing word:", word)
+			if word_id = getWordId(db, word); word_id <= 0 {
+				result, err := wordsStmt.Exec(word)
+				check(err)
+				word_id, err = result.LastInsertId()
+				check(err)
+				if word_id <= 0 {
+					log.Debugf("word %s already exists, fetching", word)
+					word_id = getWordId(db, word)
+					log.Println("Found word id:", word_id)
+				}
+			}
+			//
+			log.Debugf("word: %s => id: %d\n", word, word_id)
+			for tag, tag_id := range Tags {
+				log.Debugf("adding wt(%d,%d) // %s %s", word_id, tag_id, word, tag)
+				_, err = wtStmt.Exec(word_id, tag_id)
+				if err != nil {
+					log.Error(err)
+				}
+			}
+			word_id = 0
+		}
+	}
+	err = tx.Commit()
+	check(err)
+}
+
+// parse args of the import subcommand and exec it
 func importSubcmd(args []string) {
 	path, err := os.Getwd()
 	check(err)
@@ -340,6 +407,8 @@ func main() {
 	// Words = stringToArray(*wordsPtr)
 
 	switch subcommand {
+	case "add":
+		addSubcmd(args)
 	case "import":
 		importSubcmd(args)
 	case "search":

--- a/orunmila.go
+++ b/orunmila.go
@@ -243,6 +243,26 @@ func isFileExists(filename string) bool {
 }
 
 // parse args of the import subcommand and exec it
+func vacuumSubcmd(args []string) {
+	path, err := os.Getwd()
+	check(err)
+
+	flag := flag.NewFlagSet("vacuum", flag.ContinueOnError)
+	var (
+		dbPtr = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+	)
+	flag.Parse(args)
+
+	dsn := fmt.Sprintf("file:%s?mode=rw", *dbPtr)
+	db, err := sql.Open("sqlite3", dsn)
+	check(err)
+	defer db.Close()
+	_, err = db.Query("VACUUM")
+	check(err)
+
+}
+
+// parse args of the import subcommand and exec it
 func addSubcmd(args []string) {
 	path, err := os.Getwd()
 	check(err)
@@ -371,8 +391,6 @@ func main() {
 	check(err)
 
 	dbPtr := flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
-	// poor guy, for now
-	// wordsPtr := flag.String("words", "", "a comma separated list of words to add or search")
 	debugPtr := flag.Bool("debug", false, "enable debug")
 
 	flag.Parse()
@@ -413,6 +431,8 @@ func main() {
 		importSubcmd(args)
 	case "search":
 		searchSubcmd(args)
+	case "vacuum":
+		vacuumSubcmd(args)
 	default:
 		log.Fatalf("Unrecognized subcommand: %q", subcommand)
 		// TODO print help menu


### PR DESCRIPTION
This pr introduces two more subcommands
* `add` adds words and tags from the command line
```sh
orunmila add -tags a,b,c word1
# or just for tags
orunmila add -tags a,b,c
```

* `vacuum` performs an SQLite VACUUM operation compacting the database
