### PR TITLE
Global common flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Orunmila
-a simple tool to refine and produce lists for your bugbounty and pen-test engagements.
+A simple tool to refine and produce lists for your bugbounty and pen-test engagements.
 
-The idea behind it is fairly simple a small sqlite(??) database with each word associated tags. Each word in the dictionary can be associated with multiple tags.
+The idea behind it is fairly simple, a small sqlite(??) database with each word associated tags. Each word in the dictionary can be associated with multiple tags.
 This provides for a way to later request the words from a database based on specific tags and use the generated wordlist with you normal tools, be it ffuf, dirbuster etc.
 
 
-## Instalation
+## Installation
 
 ```sh
 GO111MODULE=on go install github.com/proditis/orunmila@latest

--- a/orunmila.go
+++ b/orunmila.go
@@ -274,10 +274,12 @@ func createDbFileifNotExist(dbPtr string) {
 // parse args of the import subcommand and exec it
 func vacuumSubcmd(args []string) {
 	flag := flag.NewFlagSet("vacuum", flag.ContinueOnError)
+
 	var (
 		dbPtr    = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 		debugPtr = flag.Bool("debug", false, "enable debug")
 	)
+
 	flag.Parse(args)
 
 	if *debugPtr {
@@ -290,10 +292,10 @@ func vacuumSubcmd(args []string) {
 	createDB(dsn)
 	db, err := sql.Open("sqlite3", dsn)
 	check(err)
+
 	defer db.Close()
 	_, err = db.Query("VACUUM")
 	check(err)
-
 }
 
 func describeSubcmd(args []string) {
@@ -331,24 +333,27 @@ func describeSubcmd(args []string) {
 	db, err := sql.Open("sqlite3", dsn)
 	check(err)
 	defer db.Close()
+
 	tx, err := db.Begin()
 	check(err)
 
 	descStmt, err := tx.Prepare("INSERT OR REPLACE INTO sysconfig(name,val) values (?,?)")
 	check(err)
 	defer descStmt.Close()
+
 	desc := strings.TrimSpace(strings.Join(flag.Args(), " "))
 	descStmt.Exec("description", desc)
 	err = tx.Commit()
 	check(err)
-
 }
 
 func infoSubcmd(args []string) {
 	flag := flag.NewFlagSet("info", flag.ContinueOnError)
+
 	var (
 		dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 	)
+
 	flag.Parse(args)
 
 	// TODO print an error message
@@ -445,7 +450,7 @@ func addSubcmd(args []string) {
 					log.Println("Found word id:", word_id)
 				}
 			}
-			//
+
 			log.Debugf("[addSubcmd] word: %s => id: %d\n", word, word_id)
 			for tag, tag_id := range Tags {
 				log.Debugf("[addSubcmd] adding wt(%d,%d) // %s %s", word_id, tag_id, word, tag)
@@ -511,8 +516,8 @@ func importSubcmd(args []string) {
 
 // parse args of the import subcommand and exec it
 func searchSubcmd(args []string) {
-
 	flag := flag.NewFlagSet("search", flag.ExitOnError)
+
 	var (
 		dbPtr    = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 		tagsPtr  = flag.String("tags", "", "a comma separated list of the tags to use")
@@ -532,10 +537,12 @@ func searchSubcmd(args []string) {
 	createDbFileifNotExist(*dbPtr)
 
 	Tags = stringToArray(*tagsPtr)
+
 	dsn := fmt.Sprintf("file:%s?mode=ro", *dbPtr)
 	db, err := sql.Open("sqlite3", dsn)
 	check(err)
 	defer db.Close()
+
 	searchWordsByTagIds(db, *tagsPtr)
 }
 

--- a/orunmila.go
+++ b/orunmila.go
@@ -478,9 +478,9 @@ func searchSubcmd(args []string) {
 
 	flag.Parse(args)
 
-	log.Debugln("using db:", *dbPtr)
-	log.Debugln("using tags:", *tagsPtr)
-	log.Println("no filename given, performing a search")
+	log.Debugln("[searchSubcmd] using db:", *dbPtr)
+	log.Debugln("[searchSubcmd] using tags:", *tagsPtr)
+	log.Println("[searchSubcmd] no filename given, performing a search")
 
 	Tags = stringToArray(*tagsPtr)
 	dsn := fmt.Sprintf("file:%s?mode=ro", *dbPtr)
@@ -526,7 +526,8 @@ func main() {
 
 	// poor guy, for now
 	//log.Debugln("using words:", *wordsPtr)
-	log.Debugln("debug:", *debugPtr)
+	log.Debugln("[main] using db:", *debugPtr)
+	log.Debugln("[main] debug mode:", *debugPtr)
 
 	if !isFileExists(*dbPtr) {
 		log.Debugln("database does not exist, creating...")

--- a/orunmila.go
+++ b/orunmila.go
@@ -296,6 +296,8 @@ func vacuumSubcmd(args []string) {
 	defer db.Close()
 	_, err = db.Query("VACUUM")
 	check(err)
+
+	log.Println("database rebuilt successfully")
 }
 
 func describeSubcmd(args []string) {

--- a/orunmila.go
+++ b/orunmila.go
@@ -261,7 +261,7 @@ func isFileExists(filename string) bool {
 }
 
 // create the db file if it doesn't exists
-func createDbFileifNotExist(dbPtr string) {
+func createDbFileifNotExists(dbPtr string) {
 	if !isFileExists(dbPtr) {
 		log.Debugln("database does not exist, creating...")
 		if dbPtr != defaultDBPath {
@@ -286,7 +286,7 @@ func vacuumSubcmd(args []string) {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	createDbFileifNotExist(*dbPtr)
+	createDbFileifNotExists(*dbPtr)
 
 	dsn := fmt.Sprintf("file:%s?mode=rw", *dbPtr)
 	createDB(dsn)
@@ -327,7 +327,7 @@ func describeSubcmd(args []string) {
 		os.Exit(1)
 	}
 
-	createDbFileifNotExist(*dbPtr)
+	createDbFileifNotExists(*dbPtr)
 
 	dsn := fmt.Sprintf("file:%s?mode=rw", *dbPtr)
 	db, err := sql.Open("sqlite3", dsn)
@@ -412,7 +412,7 @@ func addSubcmd(args []string) {
 
 	log.Infoln("[addSubcmd] Adding the given words:", flag.Args())
 
-	createDbFileifNotExist(*dbPtr)
+	createDbFileifNotExists(*dbPtr)
 
 	dsn := fmt.Sprintf("file:%s?mode=rw", *dbPtr)
 	db, err := sql.Open("sqlite3", dsn)
@@ -534,7 +534,7 @@ func searchSubcmd(args []string) {
 	log.Debugln("[searchSubcmd] using tags:", *tagsPtr)
 	log.Println("[searchSubcmd] no filename given, performing a search")
 
-	createDbFileifNotExist(*dbPtr)
+	createDbFileifNotExists(*dbPtr)
 
 	Tags = stringToArray(*tagsPtr)
 
@@ -585,7 +585,7 @@ func main() {
 	log.Debugln("[main] using db:", *dbPtr)
 	log.Debugln("[main] debug mode:", *debugPtr)
 
-	createDbFileifNotExist(*dbPtr)
+	createDbFileifNotExists(*dbPtr)
 
 	// poor guy, for now
 	// Words = stringToArray(*wordsPtr)

--- a/orunmila.go
+++ b/orunmila.go
@@ -19,6 +19,15 @@ var (
 	Words = make(map[string]int64)
 )
 
+func getDefaultDBPath() string {
+	path, err := os.Getwd()
+	check(err)
+
+	return filepath.Join(path, "orunmila.db")
+}
+
+var defaultDBPath = getDefaultDBPath()
+
 func check(e error) {
 	if e != nil {
 		log.Fatal(e)
@@ -253,12 +262,9 @@ func isFileExists(filename string) bool {
 
 // parse args of the import subcommand and exec it
 func vacuumSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
-
 	flag := flag.NewFlagSet("vacuum", flag.ContinueOnError)
 	var (
-		dbPtr = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 	)
 	flag.Parse(args)
 
@@ -273,8 +279,6 @@ func vacuumSubcmd(args []string) {
 }
 
 func describeSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
 
 	flag := flag.NewFlagSet("describe", flag.ExitOnError)
 
@@ -287,7 +291,7 @@ func describeSubcmd(args []string) {
 	}
 
 	var (
-		dbPtr = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 	)
 	flag.Parse(args)
 
@@ -314,12 +318,9 @@ func describeSubcmd(args []string) {
 }
 
 func infoSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
-
 	flag := flag.NewFlagSet("info", flag.ContinueOnError)
 	var (
-		dbPtr = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 	)
 	flag.Parse(args)
 
@@ -347,9 +348,6 @@ func infoSubcmd(args []string) {
 
 // parse args of the import subcommand and exec it
 func addSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
-
 	flag := flag.NewFlagSet("add", flag.ExitOnError)
 
 	flag.Usage = func() {
@@ -360,7 +358,7 @@ func addSubcmd(args []string) {
 	}
 
 	var (
-		dbPtr   = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr   = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 		tagsPtr = flag.String("tags", "", "a comma separated list of the tags to use")
 	)
 
@@ -428,9 +426,6 @@ func addSubcmd(args []string) {
 
 // parse args of the import subcommand and exec it
 func importSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
-
 	flag := flag.NewFlagSet("import", flag.ExitOnError)
 
 	flag.Usage = func() {
@@ -441,7 +436,7 @@ func importSubcmd(args []string) {
 	}
 
 	var (
-		dbPtr   = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr   = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 		tagsPtr = flag.String("tags", "", "a comma separated list of the tags to use")
 	)
 
@@ -474,12 +469,10 @@ func importSubcmd(args []string) {
 
 // parse args of the import subcommand and exec it
 func searchSubcmd(args []string) {
-	path, err := os.Getwd()
-	check(err)
 
 	flag := flag.NewFlagSet("search", flag.ExitOnError)
 	var (
-		dbPtr   = flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
+		dbPtr   = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
 		tagsPtr = flag.String("tags", "", "a comma separated list of the tags to use")
 	)
 
@@ -498,9 +491,6 @@ func searchSubcmd(args []string) {
 }
 
 func main() {
-	path, err := os.Getwd()
-	check(err)
-
 	flag.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), "~~~~~ orunmila word list manager ~~~~~\n\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage of orunmila:\n")
@@ -514,8 +504,10 @@ func main() {
 		fmt.Fprintln(flag.CommandLine.Output(), "  vacuum   Rebuild the database file, repacking it into a minimal amount of disk space")
 	}
 
-	dbPtr := flag.String("db", filepath.Join(path, "orunmila.db"), "the database filename (default: orunmila.db)")
-	debugPtr := flag.Bool("debug", false, "enable debug")
+	var (
+		dbPtr    = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
+		debugPtr = flag.Bool("debug", false, "enable debug")
+	)
 
 	flag.Parse()
 


### PR DESCRIPTION
* Added more context around debug message by hinting the name of the current function.
* Fixed a bug where using a specified db that wasn't created doesn't get used by subcommands, but instead uses the default one.
* Made the default file path of the db global to reduce the amount of `filepath.Join()` calls.
* Minor code cleaning/styling.