### PR TITLE
Eliminate subcommand duplications

### DIFF
--- a/orunmila.go
+++ b/orunmila.go
@@ -324,9 +324,8 @@ func describeSubcmd(args []string) {
 
 	desc := strings.TrimSpace(strings.Join(flag.Args(), " "))
 	_, err = descStmt.Exec("description", desc)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	check(err)
+
 	err = tx.Commit()
 	check(err)
 }

--- a/orunmila.go
+++ b/orunmila.go
@@ -28,8 +28,6 @@ func getDefaultDBPath() string {
 	return filepath.Join(path, "orunmila.db")
 }
 
-var defaultDBPath = getDefaultDBPath()
-
 func check(e error) {
 	if e != nil {
 		log.Fatal(e)
@@ -266,9 +264,6 @@ func isFileExists(filename string) bool {
 func createDbFileifNotExists(dbPtr string) {
 	if !isFileExists(dbPtr) {
 		log.Debugln("database does not exist, creating...")
-		if dbPtr != defaultDBPath {
-			defaultDBPath = dbPtr
-		}
 		createDB(dbPtr)
 	}
 }
@@ -338,10 +333,6 @@ func describeSubcmd(args []string) {
 
 func infoSubcmd(args []string) {
 	flag := flag.NewFlagSet("info", flag.ContinueOnError)
-
-	var (
-		dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
-	)
 
 	flag.Parse(args)
 
@@ -531,7 +522,7 @@ func main() {
 		fmt.Fprintln(flag.CommandLine.Output(), "  vacuum   Rebuild the database file, repacking it into a minimal amount of disk space")
 	}
 
-	dbPtr = flag.String("db", defaultDBPath, "the database filename (default: orunmila.db")
+	dbPtr = flag.String("db", getDefaultDBPath(), "the database filename (default: orunmila.db")
 	debugPtr = flag.Bool("debug", false, "enable debug")
 
 	flag.Parse()


### PR DESCRIPTION
This PR does the following
* makes debug and db pointers global variables
* eliminates the db/debug parsing from subcommands only uses main() the one from main
* sets logging to debug and remove from subcommands